### PR TITLE
SEO-187689-EJ2-Vue-textbox-getting-started-Page-with-redirect-links

### DIFF
--- a/ej2-vue/textbox/getting-started.md
+++ b/ej2-vue/textbox/getting-started.md
@@ -18,7 +18,7 @@ To get start quickly with Vue TextBox component, you can check on this video:
 
 ## Prerequisites
 
-[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements/)
+[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements)
 
 ## Dependencies
 


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Coverage Issues|
|Content Task Link/Mail Screenshot | NA|
|Hotfix |https://github.com/syncfusion-content/ej2-react-docs/pull/510|
|Ticket/Task link | https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/187689|
|Work link |https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B2A368E74-D539-456F-9819-C9B68637E490%7D&file=Faith.xlsx&action=default&mobileredirect=true|

Changes Made | Reason for change |
|-- | -- |
|Changed-Redirect link | To avoid redirect links | 