### PR TITLE
SEO-187689-EJ2-Vue-maps-getting-started-vue-3Page-with-redirect-links

### DIFF
--- a/ej2-vue/document-editor/getting-started.md
+++ b/ej2-vue/document-editor/getting-started.md
@@ -14,7 +14,7 @@ This article provides a step-by-step guide for setting up a Vue 2 project using 
 
 ## Prerequisites
 
-[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements/)
+[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements)
 
 ## Dependencies
 

--- a/ej2-vue/list-box/getting-started.md
+++ b/ej2-vue/list-box/getting-started.md
@@ -14,7 +14,7 @@ This article provides a step-by-step guide for setting up a Vue 2 project using 
 
 ## Prerequisites
 
-[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements/)
+[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements)
 
 ## Setting up the Vue 2 project
 

--- a/ej2-vue/maps/getting-started-vue-3.md
+++ b/ej2-vue/maps/getting-started-vue-3.md
@@ -18,7 +18,7 @@ The `Options API` is the traditional way of writing Vue.js components, where the
 
 ## Prerequisites
 
-[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements/)
+[System requirements for Syncfusion Vue UI components](https://ej2.syncfusion.com/vue/documentation/system-requirements)
 
 ## Set up the Vite project
 


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Coverage Issues|
|Content Task Link/Mail Screenshot | NA|
|Hotfix |https://github.com/syncfusion-content/ej2-vue-docs/pull/426|
|Ticket/Task link | https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/188463|
|Work link |https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B1AEC8B02-054F-41E4-A9CF-1E907D8651D6%7D&file=Faith-%20Coverage.xlsx&action=default&mobileredirect=true&ovuser=77f1fe12-b049-4919-8c50-9fb41e5bb63b%2Cfaithatienoa%40syncfusion.com&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNDA4MDIxMjAwOCIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D|

Changes Made | Reason for change |
|-- | -- |
|Changed-Redirect link | To avoid redirect links | 