### PR TITLE
fix code example in drop-down-button documentation code example

### DIFF
--- a/ej2-vue/drop-down-button/vue-3-getting-started.md
+++ b/ej2-vue/drop-down-button/vue-3-getting-started.md
@@ -165,7 +165,7 @@ export default {
 {% highlight html tabtitle="Composition API (~/src/App.vue)" %}
 
 <script setup>
-const  items:[
+const  items = [
 {
     text: 'Cut'
 },


### PR DESCRIPTION
in line (214) inside the code example it was like this (const items: []) and I fixed it by replacing "items: []" with "items = []"
because it was inside 'setup'