### PR TITLE
seo-201392-mutliple-h1-tag-vue-hotfix

### DIFF
--- a/ej2-vue/datepicker/date-masking.md
+++ b/ej2-vue/datepicker/date-masking.md
@@ -43,7 +43,7 @@ The following example demonstrates default and custom format of DatePicker compo
         
 {% previewsample "page.domainurl/code-snippet/datepicker/mask-module-cs2" %}
 
-# Configure Mask Placeholder
+## Configure Mask Placeholder
 
 You can change mask placeholder value through property `maskPlaceholder`. By default , it takes the full name of date and time co-ordinates such as `day`, `month`, `year`, `hour` etc.
 


### PR DESCRIPTION
Hi @MallikaRK

Title | Description
-- | --
|Task Category |Multiple h1 tag|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/201392/|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it.  | 




Regards, 
Asha